### PR TITLE
Scale the number of instances up to 2

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,4 +2,4 @@
 buildpack: staticfile_buildpack
 memory: 512MB
 name: federalist-proxy
-instances: 1
+instances: 2


### PR DESCRIPTION
This commit scales the number of instances of the proxy running from 1 to 2. In the [cloud.gov production ready guide](https://cloud.gov/docs/apps/production-ready/) this is described as necessary to keep the app from going down during regular maintanence.