### PR TITLE
Reduce instance memory from 512MB to 64MB

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
 buildpack: staticfile_buildpack
-memory: 512MB
+memory: 64MB
 name: federalist-proxy
-instances: 2
+instances: 4


### PR DESCRIPTION
[The Staticfile Buildpack docs](http://docs.cloudfoundry.org/buildpacks/staticfile/#memory) suggest that apps using the buildpack use 64MB of RAM. We are currently using 512MB. This commit sets the amount of RAM per instance to the suggested level, and cranks up the instance count.