### PR TITLE
Add proxy_redirect rule to remove /site/org/repo component of URLs

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -34,6 +34,7 @@ http {
     add_header X-Frame-Options "SAMEORIGIN";
     location / {
       proxy_pass <%= ENV["FEDERALIST_S3_BUCKET_URL"] %>/;
+      proxy_redirect ~*^/site/([^/]+)/([^/]+)/(.*) " /$3";
     }
   }
 }


### PR DESCRIPTION
S3 redirects paths without a trailing slash to the same path with a trailing slack. For example `/site/18f/18f.gsa.gov/blog` redirects to `/site/18f/18f.gsa.gov/blog/`.

The problem is that this redirect is then forwarded to the client through Cloudfront. So a request for `18f.gsa.gov/blog` redirects to `18f.gsa.gov/site/18f/18f.gsa.gov/blog/`.

This commit fixes that problem by adding a `proxy_redirect` rule to remove the first 3 components in the path for a redirect.