### PR TITLE
Set redirects for preview URLs

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -35,6 +35,7 @@ http {
     location / {
       proxy_pass <%= ENV["FEDERALIST_S3_BUCKET_URL"] %>/;
       proxy_redirect ~*^/site/([^/]+)/([^/]+)/(.*) " /$3";
+      proxy_redirect ~*^/preview/([^/]+)/([^/]+)/([^/]+)/(.*) " /$4";
     }
   }
 }


### PR DESCRIPTION
This commit adds a `proxy_redirect` rule for preview URLs that works the same as the rule for published site URLs. Previously preview URLs could be ignored because they were not proxied, but we expect them to be with the coming "beta domain" feature.