### PR TITLE
Add the S3 bucket url to the env in the manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,3 +3,5 @@ buildpack: staticfile_buildpack
 memory: 64MB
 name: federalist-proxy
 instances: 4
+env:
+  FEDERALIST_S3_BUCKET_URL: http://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.s3-website-us-gov-west-1.amazonaws.com


### PR DESCRIPTION
The federalist-proxy fields a large amount of traffic and as such needs to be deployed with autopilot. For this to work, environment variables need to be specified in either the manifest or a user provided service.

This commit adds the S3 bucket url to the manifest so that it doesn't need to be re-added every time we redeploy the proxy