### PR TITLE
Add robots.txt

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -32,6 +32,11 @@ http {
     server_name federalist-proxy.app.cloud.gov;
     add_header Strict-Transport-Security "max-age=31536000";
     add_header X-Frame-Options "SAMEORIGIN";
+
+    location =/robots.txt {
+      alias <%= ENV["APP_ROOT"] %>/public/robots.txt;
+    }
+
     location / {
       proxy_pass <%= ENV["FEDERALIST_S3_BUCKET_URL"] %>/;
       proxy_redirect ~*^/site/([^/]+)/([^/]+)/(.*) " /$3";

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
This commit adds a robots.txt file that is served at `/robots.txt`. This will prevent the site from being crawled and content from showing up in search engines at the proxy instead of the published site.