### PR TITLE
Setup Docker so the proxy can run locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM nginx:1.13.0
+
+# Install ruby and bundler
+RUN apt-get update
+RUN apt-get install -y build-essential ruby2.3-dev
+RUN gem install bundler
+
+# Add site files
+COPY . /src
+
+# Setup App Root
+RUN mkdir /app \
+    && mkdir -p /app/nginx/logs/ \
+    && mkdir -p /app/public \
+    && cp -r /src/* /app/public/
+
+# Set defaults for environment in nginx.conf
+ENV APP_ROOT /app
+ENV FEDERALIST_PROXY_SERVER_NAME localhost
+ENV PORT 80
+
+CMD erb /src/nginx.conf > /etc/nginx/nginx.conf && nginx

--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ This proxy adds the following headers to the response from the S3 bucket:
 
 - Strict-Transport-Security: max-age=31536000
 - X-Frame-Options: SAMEORIGIN
+
+## Running locally with Docker
+
+__NOTE: Federalist does not use Docker for the production proxy__
+
+The proxy can be run locally using [Docker Compose](https://docs.docker.com/compose/). To start the site using Docker Compose, run the following after cloning the repo:
+
+```
+docker-compose build
+docker-compose up
+```
+
+The proxy should be available at `https://localhost:1338/`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "2"
+services:
+  nginx:
+    build:
+      context: .
+    ports:
+      - 1338:80
+    environment:
+      - FEDERALIST_S3_BUCKET_URL=http://cg-f28e32aa-d42e-4906-a813-7d726f69183c.s3-website-us-gov-west-1.amazonaws.com
+      - FEDERALIST_PROXY_SERVER_NAME=localhost
+
+

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,4 +4,5 @@ memory: 64MB
 name: federalist-proxy
 instances: 4
 env:
+  FEDERALIST_PROXY_SERVER_NAME: federalist-proxy.app.cloud.gov
   FEDERALIST_S3_BUCKET_URL: http://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.s3-website-us-gov-west-1.amazonaws.com

--- a/nginx.conf
+++ b/nginx.conf
@@ -29,7 +29,7 @@ http {
 
   server {
     listen <%= ENV["PORT"] %>;
-    server_name federalist-proxy.app.cloud.gov;
+    server_name <%= ENV["FEDERALIST_PROXY_SERVER_NAME"] %>;
     add_header Strict-Transport-Security "max-age=31536000";
     add_header X-Frame-Options "SAMEORIGIN";
     location / {

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -1,0 +1,8 @@
+---
+buildpack: staticfile_buildpack
+memory: 64MB
+name: federalist-proxy-staging
+instances: 2
+env:
+  FEDERALIST_PROXY_SERVER_NAME: federalist-proxy-staging.app.cloud.gov
+  FEDERALIST_S3_BUCKET_URL: http://cg-f28e32aa-d42e-4906-a813-7d726f69183c.s3-website-us-gov-west-1.amazonaws.com


### PR DESCRIPTION
This commit adds a Dockerfile and a Docker Compose configuration which can be used to run the app locally. The app will run as if it were running in the staging environment

As part of the above change, the app also adds a staging manifest so the app's staging configuration can be described.