### PR TITLE
Swap proxy redirects for /preview and /demo

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -35,7 +35,7 @@ http {
     location / {
       proxy_pass <%= ENV["FEDERALIST_S3_BUCKET_URL"] %>/;
       proxy_redirect ~*^/site/([^/]+)/([^/]+)/(.*) " /$3";
-      proxy_redirect ~*^/preview/([^/]+)/([^/]+)/([^/]+)/(.*) " /$4";
+      proxy_redirect ~*^/demo/([^/]+)/([^/]+)/(.*) " /$3";
     }
   }
 }


### PR DESCRIPTION
This commit changes the proxy so that requests with the prefix `/demo/<org>/<repo>` trim the `/demo/<org>/<repo>` element from redirects. For requests with the prefix `/prefix/<org>/<repo>/<branch>`, it quits trimming the prefix.

This is necessary now that demo branches are published in `/demo` instead of `/preview`.