### PR TITLE
Enable gzip for more font mimetypes

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -23,7 +23,12 @@ http {
   gzip_types text/plain text/css text/js text/xml
     text/javascript application/javascript application/x-javascript
     application/json application/xml application/xml+rss
-    application/vnd.ms-fontobject application/x-font-ttf font/opentype;
+    font/ttf font/otf font/x-woff image/svg+xml
+    application/vnd.ms-fontobject
+    application/ttf application/x-ttf application/otf
+    application/x-otf application/truetype application/eot
+    application/opentype application/x-opentype application/woff
+    application/font application/font-woff woff application/font-sfnt;
 
   tcp_nopush on;
   keepalive_timeout 30;


### PR DESCRIPTION
I added all of the font mimetypes from Cloudflare's list of gzipped file types over at https://support.cloudflare.com/hc/en-us/articles/200168396-What-will-Cloudflare-gzip- 

