### PR TITLE
Remove proxy_redirect rules

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,8 +47,6 @@ http {
 
     location / {
       proxy_pass <%= ENV["FEDERALIST_S3_BUCKET_URL"] %>/;
-      proxy_redirect ~*^/site/([^/]+)/([^/]+)/(.*) " /$3";
-      proxy_redirect ~*^/demo/([^/]+)/([^/]+)/(.*) " /$3";
     }
   }
 }


### PR DESCRIPTION
After https://github.com/18F/federalist-garden-build/pull/47 the build container started creating redirect objects for the site. A result of this is that we no longer need to strip the baseurl out of demo and site paths since the BASEURL will handle that when the build is run.

This commit removes the proxy_redirect rules that strip the baseurl out of demo and site paths.