### PR TITLE
add text/html content-type to .cfm locations

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,12 +9,7 @@ http {
   log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
   access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
   default_type application/octet-stream;
-  
   include mime.types;
-  types {
-    # additional type definitions
-    text/html     cfm;
-  }
   
   sendfile on;
 
@@ -52,6 +47,13 @@ http {
     }
 
     location / {
+      # more extensions can be added inside the parentheses, separated by | characters
+      location ~* \.(cfm)$ {
+        add_header Content-Type "text/html";
+        # Notice there is no trailing slash on the proxy_pass url here
+        proxy_pass <%= ENV["FEDERALIST_S3_BUCKET_URL"] %>;
+      }
+
       proxy_pass <%= ENV["FEDERALIST_S3_BUCKET_URL"] %>/;
     }
   }


### PR DESCRIPTION
ref #19

To figure out and test this solution, since the previous attempt in #20 didn't work, I setup an instance of the proxy in my cloud.gov sandbox. It also points to the Federalist staging bucket.

* sandbox `.cfm` url, **works**: https://federalist-proxy-sandbox.app.cloud.gov/site/gsa/plainlanguage.gov/plLaw/index.cfm
* staging `.cfm` url, **doesn't work** currently: https://federalist-proxy-staging.app.cloud.gov/site/gsa/plainlanguage.gov/plLaw/index.cfm