### PR TITLE
Add CORS support for GET requests from s.codepen.io

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,9 @@
 ---
-buildpack: staticfile_buildpack
-memory: 64MB
-name: federalist-proxy
-instances: 4
-env:
-  FEDERALIST_PROXY_SERVER_NAME: federalist-proxy.app.cloud.gov
-  FEDERALIST_S3_BUCKET_URL: http://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.s3-website-us-gov-west-1.amazonaws.com
+applications:
+- name: federalist-proxy
+  buildpack: staticfile_buildpack
+  memory: 64MB
+  instances: 4
+  env:
+    FEDERALIST_PROXY_SERVER_NAME: federalist-proxy.app.cloud.gov
+    FEDERALIST_S3_BUCKET_URL: http://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.s3-website-us-gov-west-1.amazonaws.com

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,7 +10,7 @@ http {
   access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
   default_type application/octet-stream;
   include mime.types;
-  
+
   sendfile on;
 
   gzip on;
@@ -52,12 +52,34 @@ http {
       # allow for HTML "meta redirects" on pages of sites that have been migrated
       # to Federalist. For context, see https://github.com/18F/federalist-proxy/issues/19.
       #
-      # More extensions can be added inside the parentheses, separated 
+      # More extensions can be added inside the parentheses, separated
       # by | characters, e.g. `\.(cfm|php)$`.
       location ~* \.(cfm)$ {
         add_header Content-Type "text/html";
         # Notice there is no trailing slash on the proxy_pass url here.
         proxy_pass <%= ENV["FEDERALIST_S3_BUCKET_URL"] %>;
+      }
+
+      # Enable CORS support.
+      # Based on https://enable-cors.org/server_nginx.html
+      set $cors_origins 'https://s.codepen.io';
+      set $cors_methods 'GET, OPTIONS';
+      set $cors_headers 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+
+      if ($request_method = 'OPTIONS') {
+        add_header 'Access-Control-Allow-Origin' $cors_origins;
+        add_header 'Access-Control-Allow-Methods' $cors_methods;
+  
+        # Custom headers and headers various browsers *should* be OK with but aren't
+        add_header 'Access-Control-Allow-Headers' $cors_headers;
+      }
+      if ($request_method = 'GET') {
+        add_header 'Access-Control-Allow-Origin' $cors_origins;
+        add_header 'Access-Control-Allow-Methods' $cors_methods;
+
+        # Custom headers and headers various browsers *should* be OK with but aren't
+        add_header 'Access-Control-Allow-Headers' $cors_headers;
+        add_header 'Access-Control-Expose-Headers' $cors_headers;
       }
 
       proxy_pass <%= ENV["FEDERALIST_S3_BUCKET_URL"] %>/;

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -1,8 +1,9 @@
 ---
-buildpack: staticfile_buildpack
-memory: 64MB
-name: federalist-proxy-staging
-instances: 2
-env:
-  FEDERALIST_PROXY_SERVER_NAME: federalist-proxy-staging.app.cloud.gov
-  FEDERALIST_S3_BUCKET_URL: http://cg-f28e32aa-d42e-4906-a813-7d726f69183c.s3-website-us-gov-west-1.amazonaws.com
+applications:
+- name: federalist-proxy-staging
+  buildpack: staticfile_buildpack
+  memory: 64MB
+  instances: 2
+  env:
+    FEDERALIST_PROXY_SERVER_NAME: federalist-proxy-staging.app.cloud.gov
+    FEDERALIST_S3_BUCKET_URL: http://cg-f28e32aa-d42e-4906-a813-7d726f69183c.s3-website-us-gov-west-1.amazonaws.com


### PR DESCRIPTION
Based on example at https://enable-cors.org/server_nginx.html

I tested this by launching an instance of this proxy in my cloud.gov sandbox and trying it on codepen: https://codepen.io/anon/pen/zRKdaM?editors=1111

Also, I updated this app's CloudFoundry manifest files to adhere to the new format (basically just nested under an `applications` key). Ref http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#deprecated.