### PR TITLE
Use new manifest file format

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,9 @@
 ---
-buildpack: staticfile_buildpack
-memory: 64MB
-name: federalist-proxy
-instances: 4
-env:
-  FEDERALIST_PROXY_SERVER_NAME: federalist-proxy.app.cloud.gov
-  FEDERALIST_S3_BUCKET_URL: http://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.s3-website-us-gov-west-1.amazonaws.com
+applications:
+- name: federalist-proxy
+  buildpack: staticfile_buildpack
+  memory: 64MB
+  instances: 4
+  env:
+    FEDERALIST_PROXY_SERVER_NAME: federalist-proxy.app.cloud.gov
+    FEDERALIST_S3_BUCKET_URL: http://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.s3-website-us-gov-west-1.amazonaws.com

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -1,8 +1,9 @@
 ---
-buildpack: staticfile_buildpack
-memory: 64MB
-name: federalist-proxy-staging
-instances: 2
-env:
-  FEDERALIST_PROXY_SERVER_NAME: federalist-proxy-staging.app.cloud.gov
-  FEDERALIST_S3_BUCKET_URL: http://cg-f28e32aa-d42e-4906-a813-7d726f69183c.s3-website-us-gov-west-1.amazonaws.com
+applications:
+- name: federalist-proxy-staging
+  buildpack: staticfile_buildpack
+  memory: 64MB
+  instances: 2
+  env:
+    FEDERALIST_PROXY_SERVER_NAME: federalist-proxy-staging.app.cloud.gov
+    FEDERALIST_S3_BUCKET_URL: http://cg-f28e32aa-d42e-4906-a813-7d726f69183c.s3-website-us-gov-west-1.amazonaws.com


### PR DESCRIPTION
Basically just nest everything under an `applications:` key. No functional changes, but the old version will be deprecated at some point in the future so this just gets us ready for that. See http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#deprecated

ref #28.