### PR TITLE
Route requests to bucket based on subdomain

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,5 +5,5 @@ applications:
   memory: 64MB
   instances: 4
   env:
-    FEDERALIST_PROXY_SERVER_NAME: federalist-proxy.app.cloud.gov
+    FEDERALIST_PROXY_SERVER_NAME: federalist-proxy
     FEDERALIST_S3_BUCKET_URL: http://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.s3-website-us-gov-west-1.amazonaws.com

--- a/nginx.conf
+++ b/nginx.conf
@@ -8,7 +8,7 @@ http {
   log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
   default_type application/octet-stream;
   include mime.types;
-  
+
   sendfile on;
 
   gzip on;
@@ -37,9 +37,21 @@ http {
 
   server {
     listen {{port}};
-    server_name {{env "FEDERALIST_PROXY_SERVER_NAME"}};
+    server_name  ~^(?<name>.+)\.app\.cloud\.gov$;
+    resolver 8.8.8.8 valid=60s;
     add_header Strict-Transport-Security "max-age=31536000";
     add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Upstream '$name' always;
+
+    if ($name ~ ({{env "FEDERALIST_PROXY_SERVER_NAME"}})) {
+      set $bucket_url {{env "FEDERALIST_S3_BUCKET_URL"}};
+    }
+
+    if ($name !~ ({{env "FEDERALIST_PROXY_SERVER_NAME"}})) {
+      set $bucket_url http://$name.s3-website-us-gov-west-1.amazonaws.com;
+    }
+
+    add_header X-bucket '$bucket_url' always;
 
     location =/robots.txt {
       alias {{env "HOME"}}/public/robots.txt;
@@ -51,15 +63,15 @@ http {
       # allow for HTML "meta redirects" on pages of sites that have been migrated
       # to Federalist. For context, see https://github.com/18F/federalist-proxy/issues/19.
       #
-      # More extensions can be added inside the parentheses, separated 
+      # More extensions can be added inside the parentheses, separated
       # by | characters, e.g. `\.(cfm|php)$`.
       location ~* \.(cfm)$ {
         add_header Content-Type "text/html";
         # Notice there is no trailing slash on the proxy_pass url here.
-        proxy_pass {{env "FEDERALIST_S3_BUCKET_URL"}};
+        proxy_pass $bucket_url;
       }
 
-      proxy_pass {{env "FEDERALIST_S3_BUCKET_URL"}}/;
+      proxy_pass $bucket_url;
     }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -41,7 +41,6 @@ http {
     resolver 8.8.8.8 valid=60s;
     add_header Strict-Transport-Security "max-age=31536000";
     add_header X-Frame-Options "SAMEORIGIN";
-    add_header X-Upstream '$name' always;
 
     if ($name ~ ({{env "FEDERALIST_PROXY_SERVER_NAME"}})) {
       set $bucket_url {{env "FEDERALIST_S3_BUCKET_URL"}};
@@ -50,8 +49,6 @@ http {
     if ($name !~ ({{env "FEDERALIST_PROXY_SERVER_NAME"}})) {
       set $bucket_url http://$name.s3-website-us-gov-west-1.amazonaws.com;
     }
-
-    add_header X-bucket '$bucket_url' always;
 
     location =/robots.txt {
       alias {{env "HOME"}}/public/robots.txt;

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -5,5 +5,5 @@ applications:
   memory: 64MB
   instances: 2
   env:
-    FEDERALIST_PROXY_SERVER_NAME: federalist-proxy-staging.app.cloud.gov
+    FEDERALIST_PROXY_SERVER_NAME: federalist-proxy-staging
     FEDERALIST_S3_BUCKET_URL: http://cg-f28e32aa-d42e-4906-a813-7d726f69183c.s3-website-us-gov-west-1.amazonaws.com


### PR DESCRIPTION
## Description

Updated federalist proxy to use the subdomain name from requests ie(`<name>.app.cloud.gov`) to either route requests to the shared bucket when coming from `https://federalist-proxy.app.cloud.gov` or to the private bucket when coming from a route `https://<bucket-name>.app.cloud.gov`

## Implementation

- [x] Currently will work for all sites
- [x] Update [federalist](https://github.com/18f/federalist) to generate a cloud foundry route to attach to the federalist-proxy app ie(https://<bucket-name>.app.cloud.gov) when a new site with a private bucket is created.