### PR TITLE
increase memory and add preload directive to hsts header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -39,7 +39,7 @@ http {
     listen {{port}};
     server_name  ~^(?<name>.+)\.app\.cloud\.gov$;
     resolver 8.8.8.8 valid=60s;
-    add_header Strict-Transport-Security "max-age=31536000";
+    add_header Strict-Transport-Security "max-age=31536000; preload";
     add_header X-Frame-Options "SAMEORIGIN";
 
     if ($name ~ ({{env "FEDERALIST_PROXY_SERVER_NAME"}})) {


### PR DESCRIPTION
GSA to comply with Binding Operational Directive (BOD) 18-01


HSTS preloading is an opt in process in which the domain will be added to the preload lists for various browsers. These lists are hard coded within the various browsers (Chrome, IE, Firefox) and are used to further enforce HTTPS only for the domain. This in turn will provide enhanced security for any clients that connect to the aforementioned domain.. 

Remaining requirements to qualify for preload are listed below as indicated by https://hstspreload.org/ :
Examine all subdomains (and nested subdomains) of your site and make sure that they work properly over HTTPS  
Include the preload flag within the domains HSTS header.
Example:  max-age=63072000; includeSubDomains; preload