### PR TITLE
Add and configure http health check endpoint

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -7,3 +7,5 @@ applications:
   env:
     FEDERALIST_PROXY_SERVER_NAME: federalist-proxy
     FEDERALIST_S3_BUCKET_URL: http://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.s3-website-us-gov-west-1.amazonaws.com
+  health-check-type: http
+  health-check-http-endpoint: /health

--- a/nginx.conf
+++ b/nginx.conf
@@ -56,6 +56,7 @@ http {
 
     location =/health {
       access_log off;
+      add_header Content-Type "text/html";
       return 200;
     }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -54,6 +54,11 @@ http {
       alias {{env "HOME"}}/public/robots.txt;
     }
 
+    location =/health {
+      access_log off;
+      return 200;
+    }
+
     location / {
       # Specify the Content-Type header as "text/html" for requests that look
       # like they are for files with specific extensions. This is primarily to

--- a/staging_manifest.yml
+++ b/staging_manifest.yml
@@ -7,3 +7,5 @@ applications:
   env:
     FEDERALIST_PROXY_SERVER_NAME: federalist-proxy-staging
     FEDERALIST_S3_BUCKET_URL: http://cg-f28e32aa-d42e-4906-a813-7d726f69183c.s3-website-us-gov-west-1.amazonaws.com
+  health-check-type: http
+  health-check-http-endpoint: /health


### PR DESCRIPTION
Cloud Foundry recommends using an http health check when possible. This will be a better indication of whether or not the application is ready to serve requests.

Add `access_log off;` since we don't need these requests to clog up the logs.