### PR TITLE
includeSubDomains for HSTS for some TTS domains

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -39,7 +39,15 @@ http {
   map_hash_bucket_size 256;
   map $host $sts {
     default "max-age=31536000; preload";
+
+    # enforce for subdomains, as a requirement for HSTS preload
+    # https://hstspreload.org/
     {{env "CLOUD_GOV_HOST"}} "max-age=31536000; includeSubDomains; preload";
+    code.gov "max-age=31536000; includeSubDomains; preload";
+    connect.gov "max-age=31536000; includeSubDomains; preload";
+    presidentialinnovationfellows.gov "max-age=31536000; includeSubDomains; preload";
+    sbst.gov "max-age=31536000; includeSubDomains; preload";
+    vote.gov "max-age=31536000; includeSubDomains; preload";
   }
 
   server {


### PR DESCRIPTION
Note I wasn't sure how to test this change; I'm _pretty sure_ the `$host` will match, but worst case is that the requests won't match.