### PR TITLE
On HOLD: Remove hsts for login.gov

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -9,8 +9,8 @@ applications:
     FEDERALIST_S3_BUCKET_URL: http://((shared-bucket)).s3-website-us-gov-west-1.amazonaws.com
     DEDICATED_S3_BUCKET_URL: http://$name.s3-website-us-gov-west-1.amazonaws.com
     DNS_RESOLVER: '8.8.8.8'
-    # cloud.gov|code.gov|presidentialinnovationfellows.gov|sbst.gov|vote.gov|connect.gov|login.gov
-    INCLUDE_SUBDOMAINS: cg-88d42ca6-59d7-47e0-9500-4dd9251360b9|federalist-88023b0b-4406-431f-932d-5fd82c70c515|federalist-f7cff978-bf3d-4aaa-bbff-a77bbfc6d827|federalist-c1c3cd8c-125e-41f5-a533-f42e03c01486|cg-9e8debaf-b030-4825-a43c-cb2bc850c96c|federalist-a2074193-6730-4022-a8fd-466df53b6fa5|federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5
+    # cloud.gov|code.gov|presidentialinnovationfellows.gov|sbst.gov|vote.gov|connect.gov
+    INCLUDE_SUBDOMAINS: cg-88d42ca6-59d7-47e0-9500-4dd9251360b9|federalist-88023b0b-4406-431f-932d-5fd82c70c515|federalist-f7cff978-bf3d-4aaa-bbff-a77bbfc6d827|federalist-c1c3cd8c-125e-41f5-a533-f42e03c01486|cg-9e8debaf-b030-4825-a43c-cb2bc850c96c|federalist-a2074193-6730-4022-a8fd-466df53b6fa5
     DOMAIN: ((domain))
   health-check-type: http
   health-check-http-endpoint: /health


### PR DESCRIPTION
## Changes proposed in this pull request:
- login.gov will be moving to the pages-redirects ( https://github.com/18F/pages-redirects/pull/186 )

## security considerations
None - removing a domain's custom hsts 



