### PR TITLE
remove proxy_ssl_verify

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -12,6 +12,6 @@ applications:
     # cloud.gov|code.gov|presidentialinnovationfellows.gov|sbst.gov|vote.gov|connect.gov|login.gov
     INCLUDE_SUBDOMAINS: cg-88d42ca6-59d7-47e0-9500-4dd9251360b9|federalist-88023b0b-4406-431f-932d-5fd82c70c515|federalist-f7cff978-bf3d-4aaa-bbff-a77bbfc6d827|federalist-c1c3cd8c-125e-41f5-a533-f42e03c01486|cg-9e8debaf-b030-4825-a43c-cb2bc850c96c|federalist-a2074193-6730-4022-a8fd-466df53b6fa5|federalist-17bd62cc-77b7-4687-9c62-39b462ce6fd5
     DOMAIN: ((domain))
-    PROXY_SSL_VERIFY: 'on'
+    PROXY_SSL_VERIFY: 'off'
   health-check-type: http
   health-check-http-endpoint: /health

--- a/bin/parse-conf.js
+++ b/bin/parse-conf.js
@@ -90,8 +90,7 @@ function parseEnv({
   PROXY_WWW: HOME,
   PROXY_PORT,
   DNS_RESOLVER,
-  DOMAIN,
-  PROXY_SSL_VERIFY
+  DOMAIN
 }) {
   return {
     INCLUDE_SUBDOMAINS,
@@ -101,8 +100,7 @@ function parseEnv({
     HOME,
     PROXY_PORT,
     DNS_RESOLVER,
-    DOMAIN,
-    PROXY_SSL_VERIFY
+    DOMAIN
   }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,6 @@ services:
       PROXY_WWW: '/usr/share/nginx/html'
       PROXY_PORT: 8000
       DNS_RESOLVER: '127.0.0.11'
-      PROXY_SSL_VERIFY: 'off'
       # Determines the url to test against in the test suite
       PROXY_URL: 'http://nginx:8000'
       DOMAIN: app\.cloud\.gov

--- a/nginx.conf
+++ b/nginx.conf
@@ -34,7 +34,6 @@ http {
   keepalive_timeout 30;
   port_in_redirect off; # Ensure that redirects don't include the internal container PORT - {{port}}
   server_tokens off;
-  proxy_ssl_verify {{env "PROXY_SSL_VERIFY"}};
 
   map_hash_max_size 64;
   map_hash_bucket_size 256;


### PR DESCRIPTION
## Changes proposed in this pull request:
- remove `PROXY_SSL_VERIFY`

This removes this setting from nginx. It isn't necessary to proxy over https and requires the explicit installation of certs from the upstream.

## security considerations
SSL still in effect.
