### PR TITLE
drop conditional headers on proxied calls

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -104,6 +104,16 @@ http {
     
       proxy_pass $bucket_url;
       proxy_intercept_errors on;
+
+      # Cloudfront forwards these but doesn't consider them part of the cache key
+      # so drop them before passing to the origin, since responses aren't actually cacheable
+      proxy_set_header If-Match "";
+      proxy_set_header If-None-Match "";
+      proxy_set_header If-Modified-Since "";
+      proxy_set_header If-Unmodified-Since "";
+      proxy_set_header Range "";
+      proxy_set_header If-Range "";
+
       error_page 404 403 =404 @notfound;
     }
   }

--- a/nginx.conf
+++ b/nginx.conf
@@ -35,6 +35,15 @@ http {
   port_in_redirect off; # Ensure that redirects don't include the internal container PORT - {{port}}
   server_tokens off;
 
+  # Cloudfront forwards these but doesn't consider them part of the cache key
+  # so drop them before passing to the origin, since responses aren't actually cacheable
+  proxy_set_header If-Match "";
+  proxy_set_header If-None-Match "";
+  proxy_set_header If-Modified-Since "";
+  proxy_set_header If-Unmodified-Since "";
+  proxy_set_header Range "";
+  proxy_set_header If-Range "";
+
   map_hash_max_size 64;
   map_hash_bucket_size 256;
   map $name $sts {
@@ -104,15 +113,6 @@ http {
     
       proxy_pass $bucket_url;
       proxy_intercept_errors on;
-
-      # Cloudfront forwards these but doesn't consider them part of the cache key
-      # so drop them before passing to the origin, since responses aren't actually cacheable
-      proxy_set_header If-Match "";
-      proxy_set_header If-None-Match "";
-      proxy_set_header If-Modified-Since "";
-      proxy_set_header If-Unmodified-Since "";
-      proxy_set_header Range "";
-      proxy_set_header If-Range "";
 
       error_page 404 403 =404 @notfound;
     }


### PR DESCRIPTION


## Changes proposed in this pull request:
- Conditional headers are forwarded by cloudfront but not part of the cache key so we get cached responses that don't make sense for future requests. Drop them here, so our cache stays valid

## security considerations
None