### PR TITLE
Update tests and return correct 404

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       PORT: 8001
       BUCKET_TYPE: dedicated
+      PATH_PREFIX: 'site/owner/repo'
   mock-shared:
     image: node:14
     volumes:
@@ -18,6 +19,7 @@ services:
     environment:
       PORT: 8001
       BUCKET_TYPE: shared
+      PATH_PREFIX: 'site/owner/repo'
   nginx:
     image: openresty/openresty:1.19.9.1-4-buster
     volumes:
@@ -43,6 +45,7 @@ services:
       PROXY_PORT: 8000
       DNS_RESOLVER: '127.0.0.11'
       # Determines the url to test against in the test suite
+      PATH_PREFIX: 'site/owner/repo'
       PROXY_URL: 'http://nginx:8000'
       S3_ENDPOINT: s3-fips.us-gov-west-1.amazonaws.com
       DEDICATED_AWS_ACCESS_KEY_ID: ${DEDICATED_AWS_ACCESS_KEY_ID}

--- a/nginx.conf
+++ b/nginx.conf
@@ -76,7 +76,7 @@ http {
     }
 
     location @notfound {
-      proxy_pass $bucket_url/404.html;
+      proxy_pass $bucket_url/$path_prefix/404.html;
     }
 
     location @proxy {
@@ -86,39 +86,43 @@ http {
     }
     
     location / {
-      # Specify the Content-Type header as "text/html" for requests that look
-      # like they are for files with specific extensions. This is primarily to
-      # allow for HTML "meta redirects" on pages of sites that have been migrated
-      # to Federalist. For context, see https://github.com/18F/federalist-proxy/issues/19.
-      #
-      # More extensions can be added inside the parentheses, separated
-      # by | characters, e.g. `\.(cfm|php)$`.
-      location ~* \.(cfm)$ {
-        add_header Content-Type "text/html";
-        add_header Strict-Transport-Security $sts always;
-        add_header X-Frame-Options "SAMEORIGIN";
-        add_header X-Server "Federalist";
+      # nginx does not like `{3}`
+      location ~ ^/(?<path_prefix>([^/]+/[^/]+/[^/]+))/ {
 
+        # Specify the Content-Type header as "text/html" for requests that look
+        # like they are for files with specific extensions. This is primarily to
+        # allow for HTML "meta redirects" on pages of sites that have been migrated
+        # to Federalist. For context, see https://github.com/18F/federalist-proxy/issues/19.
+        #
+        # More extensions can be added inside the parentheses, separated
+        # by | characters, e.g. `\.(cfm|php)$`.
+        location ~* \.(cfm)$ {
+          add_header Content-Type "text/html";
+          add_header Strict-Transport-Security $sts always;
+          add_header X-Frame-Options "SAMEORIGIN";
+          add_header X-Server "Federalist";
+
+          proxy_pass $bucket_url;
+          proxy_hide_header Content-Type;
+          proxy_intercept_errors on;
+          error_page 404 403 =404 @notfound;
+        }
+
+        # Match paths without extensions or query paramters
+        location ~ ^([^.\?]*[^/])$ {
+          proxy_pass $bucket_url$uri/index.html;
+          proxy_intercept_errors on;
+          error_page 404 403 = @proxy;
+        }
+
+        location ~ /$ {
+          rewrite ^(.*)$ $1index.html last;
+        }
+      
         proxy_pass $bucket_url;
-        proxy_hide_header Content-Type;
         proxy_intercept_errors on;
         error_page 404 403 =404 @notfound;
       }
-
-      # Match paths without extensions or query paramters
-      location ~ ^([^.\?]*[^/])$ {
-        proxy_pass $bucket_url$uri/index.html;
-        proxy_intercept_errors on;
-        error_page 404 403 = @proxy;
-      }
-
-      location ~ /$ {
-        rewrite ^(.*)$ $1index.html last;
-      }
-    
-      proxy_pass $bucket_url;
-      proxy_intercept_errors on;
-      error_page 404 403 =404 @notfound;
     }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -53,6 +53,11 @@ http {
     ~^({{env "INCLUDE_SUBDOMAINS"}})$ "max-age=31536000; preload; includeSubDomains";
   }
 
+  map $name $bucket_url {
+    default {{env "DEDICATED_S3_BUCKET_URL"}};
+    ~({{env "FEDERALIST_PROXY_SERVER_NAME"}}) {{env "FEDERALIST_S3_BUCKET_URL"}};
+  }
+
   server {
     listen {{port}};
     server_name  ~^(?<name>.+)\.{{env "DOMAIN"}}$;
@@ -60,14 +65,6 @@ http {
     add_header Strict-Transport-Security $sts always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Server "Federalist" always;
-
-    if ($name ~ ({{env "FEDERALIST_PROXY_SERVER_NAME"}})) {
-      set $bucket_url {{env "FEDERALIST_S3_BUCKET_URL"}};
-    }
-
-    if ($name !~ ({{env "FEDERALIST_PROXY_SERVER_NAME"}})) {
-      set $bucket_url {{env "DEDICATED_S3_BUCKET_URL"}};
-    }
 
     location =/robots.txt {
       alias {{env "HOME"}}/public/robots.txt;

--- a/nginx.conf
+++ b/nginx.conf
@@ -50,7 +50,7 @@ http {
   map_hash_bucket_size 256;
   map $name $sts {
     default "max-age=31536000; preload";
-    ~^({{env "INCLUDE_SUBDOMAINS"}})$ "max-age=31536000; includeSubDomains; preload";
+    ~^({{env "INCLUDE_SUBDOMAINS"}})$ "max-age=31536000; preload; includeSubDomains";
   }
 
   server {
@@ -58,8 +58,8 @@ http {
     server_name  ~^(?<name>.+)\.{{env "DOMAIN"}}$;
     resolver {{env "DNS_RESOLVER"}} valid=60s;
     add_header Strict-Transport-Security $sts always;
-    add_header X-Frame-Options "SAMEORIGIN";
-    add_header X-Server "Federalist";
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Server "Federalist" always;
 
     if ($name ~ ({{env "FEDERALIST_PROXY_SERVER_NAME"}})) {
       set $bucket_url {{env "FEDERALIST_S3_BUCKET_URL"}};
@@ -98,7 +98,10 @@ http {
       # by | characters, e.g. `\.(cfm|php)$`.
       location ~* \.(cfm)$ {
         add_header Content-Type "text/html";
-        # Notice there is no trailing slash on the proxy_pass url here.
+        add_header Strict-Transport-Security $sts always;
+        add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Server "Federalist";
+
         proxy_pass $bucket_url;
         proxy_hide_header Content-Type;
         proxy_intercept_errors on;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "parse": "node ./bin/parse-conf.js",
     "parse:integration": "INTEGRATION=true node ./bin/parse-conf.js",
     "test": "mocha test/**/*.js",
-    "test:integration": "mocha --require test/s3Fixtures.js test/**/*.js"
+    "test:integration": "mocha --require test/integrationTestsHooks.js test/**/*.js"
   },
   "dependencies": {
     "aws-sdk": "^2.1045.0",

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,45 @@
+const { PATH_PREFIX } = process.env;
+
+const prefixPath = (path) => `${PATH_PREFIX}/${path}`;
+
+function getFixtures(bucketType) {
+  return {
+    [prefixPath('file')]: {
+      content: 'file',
+      extras: { ContentType: 'text/html' },
+    }, 
+    [prefixPath('file/index.html')]: {
+      content: 'file2',
+      extras: { ContentType: 'text/html' },
+    },
+    [prefixPath('404.html')]: {
+      content: '<h1>4044444444</h1>',
+      extras: { ContentType: 'text/html' },
+    },
+    [prefixPath('test/helloworld.cfm')]: {
+      content: '',
+      extras: { ContentType: 'foobar' },
+    },
+    [prefixPath('bucket.html')]: {
+      content: bucketType,
+      extras: { ContentType: 'text/html' },
+    },
+    [prefixPath('no-content-type')]: {
+      content: 'no-content-type',
+      extras: {},
+    },
+    [prefixPath('redirect-object')]: {
+      content: '/redirect-object/index.html',
+      extras: { 'x-amz-website-redirect-location': '/redirect-object/index.html' },
+    },
+    [prefixPath('redirect-object/index.html')]: {
+      content: 'redirect-object-target',
+      extras: { ContentType: 'text/html' },
+    },
+  };
+};
+
+module.exports = {
+  dedicated: getFixtures('dedicated'),
+  shared: getFixtures('shared')
+}

--- a/test/integrationTestsHooks.js
+++ b/test/integrationTestsHooks.js
@@ -1,4 +1,5 @@
 const AWS = require('aws-sdk');
+const Fixtures = require('./fixtures.js');
 
 const {
   DEDICATED_AWS_ACCESS_KEY_ID,
@@ -9,43 +10,6 @@ const {
   SHARED_S3_BUCKET
 } = process.env;
 
-function getFixtures(bucketType) {
-  return {
-    'file': {
-      content: 'file',
-      extras: { ContentType: 'text/html' },
-    }, 
-    'file/index.html': {
-      content: 'file2',
-      extras: { ContentType: 'text/html' },
-    },
-    '404.html': {
-      content: '<h1>4044444444</h1>',
-      extras: { ContentType: 'text/html' },
-    },
-    'test/helloworld.cfm': {
-      content: '',
-      extras: { ContentType: 'foobar' },
-    },
-    'bucket.html': {
-      content: bucketType,
-      extras: { ContentType: 'text/html' },
-    },
-    'no-content-type': {
-      content: 'no-content-type',
-      extras: {},
-    },
-    'redirect-object': {
-      content: '/redirect-object/index.html',
-      extras: { 'x-amz-website-redirect-location': '/redirect-object/index.html' },
-    },
-    'redirect-object/index.html': {
-      content: 'redirect-object-target',
-      extras: { ContentType: 'text/html' },
-    },
-  };
-};
-
 const buckets = {
   dedicated: {
     bucket: DEDICATED_S3_BUCKET,
@@ -54,7 +18,7 @@ const buckets = {
       secretAccessKey: DEDICATED_AWS_SECRET_ACCESS_KEY,
       apiVersion: '2006-03-01',
     },
-    fixtures: getFixtures('dedicated'),
+    fixtures: Fixtures.dedicated,
   },
   shared: {
     bucket: SHARED_S3_BUCKET,
@@ -63,7 +27,7 @@ const buckets = {
       secretAccessKey: SHARED_AWS_SECRET_ACCESS_KEY,
       apiVersion: '2006-03-01',
     },
-    fixtures: getFixtures('shared'),
+    fixtures: Fixtures.shared,
   }
 };
 

--- a/test/main.js
+++ b/test/main.js
@@ -1,9 +1,22 @@
-const request = require('supertest');
 const { expect } = require('chai');
+const supertest = require('supertest');
 
 const { parseConf } = require('../bin/parse-conf');
 
-const { PROXY_URL: app, DOMAIN: DOMAIN } = process.env;
+const {
+  PROXY_URL: app,
+  DOMAIN,
+  INCLUDE_SUBDOMAINS,
+} = process.env;
+
+supertest.Test.prototype.expectStandardHeaders = function() {
+  this.expect('X-Frame-Options', 'SAMEORIGIN');
+  this.expect('X-Server', 'Federalist');
+  this.expect('Strict-Transport-Security', /max-age=31536000; preload/);
+  return this;
+}
+
+const request = supertest(app);
 
 describe('parse-conf', () => {
   it('removes `daemon` configuration', () => {
@@ -62,18 +75,20 @@ describe('parse-conf', () => {
 
 describe('robots.txt', () => {
   it('is available', () => {
-    return request(app)
+    return request
       .get('/robots.txt')
+      .expectStandardHeaders()
       .expect(200)
       .expect('Content-Type', /text\/plain/)
-      .then(matchText(/Disallow/));
+      .expect(/Disallow/);
   });
 });
 
 describe('Health check', () => {
   it('returns 200', () => {
-    return request(app)
+    return request
       .get('/health')
+      .expectStandardHeaders()
       .expect(200);
   });
 });
@@ -82,14 +97,14 @@ describe('For `federalist-proxy-staging` hosts', () => {
   const host = 'federalist-proxy-staging.app.cloud.gov';
 
   it('returns results from the SHARED bucket', () => {
-    return request(app)
+    return request
       .get('/bucket.html')
       .set('Host', host)
+      .expectStandardHeaders()
       .expect(200)
-      .then(matchText(/shared/i));
+      .expect(/shared/i);
   });
 
-  describe('Headers', headerSpecs(host));
   describe('Paths', pathSpecs(host));
 });
 
@@ -97,49 +112,51 @@ describe('For non-`federalist-proxy-staging` hosts', () => {
   const host = 'foobar.app.cloud.gov';
 
   it('returns results from the DEDICATED bucket', () => {
-    return request(app)
+    return request
       .get('/bucket.html')
       .set('Host', host)
+      .expectStandardHeaders()
       .expect(200)
-      .then(matchText(/dedicated/i));
+      .expect(/dedicated/i);
   });
 
-  describe('Headers', headerSpecs(host));
   describe('Paths', pathSpecs(host));
 });
 
 describe('For `includeSubdomains` specific hosts', () => {
-  const subs = process.env.INCLUDE_SUBDOMAINS.split('|');
+  const subs = INCLUDE_SUBDOMAINS.split('|');
   for(const sub of subs) {
     const host = `${sub}.app.cloud.gov`;
 
     it('returns results from the DEDICATED bucket', () => {
-      return request(app)
+      return request
         .get('/bucket.html')
         .set('Host', host)
+        .expectStandardHeaders()
         .expect(200)
-        .then(matchText(/dedicated/i));
+        .expect(/dedicated/i);
     });
 
     describe('Headers', () => {
       it('includes expected headers', () => {
-        return request(app)
+        return request
           .get('/file')
           .set('Host', host)
+          .expectStandardHeaders()
           .expect(200)
           .expect('Content-Type', /charset=utf-8/)
-          .expect('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload')
-          .expect('X-Frame-Options', 'SAMEORIGIN')
-          .expect('X-Server', 'Federalist');
+          .expect('Strict-Transport-Security', 'max-age=31536000; preload; includeSubDomains')
       });
 
       describe('For .cfm files', () => {
         it('includes text/html content type header', () => {
-          return request(app)
+          return request
             .get('/test/helloworld.cfm')
             .set('Host', host)
+            .expectStandardHeaders()
             .expect(200)
-            .expect('Content-Type', /text\/html/);
+            .expect('Content-Type', /text\/html/)
+            .expect('Strict-Transport-Security', 'max-age=31536000; preload; includeSubDomains');
         });
       });
     });
@@ -149,18 +166,18 @@ describe('For `includeSubdomains` specific hosts', () => {
 
 function pathSpecs(host) {
   return () => {
-
     describe('/<some-path>', () => {
       describe('when the file is a redirect object', () => {
         it('serves the content at the redirect location', () => {
           const path = '/redirect-object';
           
-          return request(app)
+          return request
             .get(path)
             .set('Host', host)
+            .expectStandardHeaders()
             .expect(200)
             .expect('Content-Type', 'text/html; charset=utf-8')
-            .then(matchText(/redirect-object-target/i));
+            .expect(/redirect-object-target/i);
         });
       });
 
@@ -168,12 +185,13 @@ function pathSpecs(host) {
         it('serves the file', () => {
           const path = '/file';
 
-          return request(app)
+          return request
             .get(path)
             .set('Host', host)
+            .expectStandardHeaders()
             .expect(200)
             .expect('Content-Type', 'text/html; charset=utf-8')
-            .then(matchText(/file/i));
+            .expect(/file/i);
         });
       });
 
@@ -181,9 +199,10 @@ function pathSpecs(host) {
         it('serves the file', () => {
           const path = '/no-content-type';
 
-          return request(app)
+          return request
             .get(path)
             .set('Host', host)
+            .expectStandardHeaders()
             .expect(200)
             .expect('Content-Type', 'application/octet-stream')
             .then(matchBody(/no-content-type/i));
@@ -194,11 +213,12 @@ function pathSpecs(host) {
         it('serves the default 404.html', () => {
           const path = '/unicorn';
 
-          return request(app)
+          return request
             .get(path)
             .set('Host', host)
+            .expectStandardHeaders()
             .expect(404)
-            .then(matchText(/4044444444/i));
+            .expect(/4044444444/i);
         });
       })
     });
@@ -207,22 +227,24 @@ function pathSpecs(host) {
       describe('when /<some-path>/index.html exists', () => {
         it('serves /<some-path>/index.html', () => {
           const path = '/file/';
-          return request(app)
+          return request
             .get(path)
             .set('Host', host)
+            .expectStandardHeaders()
             .expect(200)
-            .then(matchText(/file2/i));
+            .expect(/file2/i);
         });
       });
 
       describe('when /<some-path>/index.html does not exist', () => {
         it('serves the default 404.html', () => {
           const path = '/unicorn/';
-          return request(app)
+          return request
             .get(path)
             .set('Host', host)
+            .expectStandardHeaders()
             .expect(404)
-            .then(matchText(/4044444444/i));
+            .expect(/4044444444/i);
         });
       });
     });
@@ -231,37 +253,13 @@ function pathSpecs(host) {
       describe('when /<some-path>/index.html exists', () => {
         it('serves /<some-path>/index.html', () => {
           const path = '/file/index.html';
-          return request(app)
+          return request
             .get(path)
             .set('Host', host)
+            .expectStandardHeaders()
             .expect(200)
-            .then(matchText(/file2/i));
+            .expect(/file2/i);
         });
-      });
-    });
-  };
-}
-
-function headerSpecs(host) {
-  return () => {
-    it('includes expected headers', () => {
-      return request(app)
-        .get('/file')
-        .set('Host', host)
-        .expect(200)
-        .expect('Content-Type', /charset=utf-8/)
-        .expect('Strict-Transport-Security', 'max-age=31536000; preload')
-        .expect('X-Frame-Options', 'SAMEORIGIN')
-        .expect('X-Server', 'Federalist');
-    });
-
-    describe('For .cfm files', () => {
-      it('includes text/html content type header', () => {
-        return request(app)
-          .get('/test/helloworld.cfm')
-          .set('Host', host)
-          .expect(200)
-          .expect('Content-Type', /text\/html/);
       });
     });
   };
@@ -269,8 +267,4 @@ function headerSpecs(host) {
 
 function matchBody(regex) {
   return response => expect(response.body.toString()).to.match(regex);
-}
-
-function matchText(regex) {
-  return response => expect(response.text).to.match(regex);
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Returns the actual 404.html in the build context (site/demo/preview) root
- Updates tests to use prefix paths and consolidate some stuff
-

## security considerations
None
