### PR TITLE
Explicitly redirect to https and a little refactoring

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -60,7 +60,7 @@ http {
 
   server {
     listen {{port}};
-    server_name  ~^(?<name>.+)\.{{env "DOMAIN"}}$;
+    server_name ~^(?<name>.+)\.{{env "DOMAIN"}}$;
     resolver {{env "DNS_RESOLVER"}} valid=60s;
     add_header Strict-Transport-Security $sts always;
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -75,48 +75,45 @@ http {
       return 200 "Ok";
     }
 
+    # Match paths ending in '/'
+    location ~ /$ {
+      rewrite ^(.*)$ $1index.html last;
+    }
+
+    # Specify the Content-Type header as "text/html" for requests that look
+    # like they are for files with specific extensions. This is primarily to
+    # allow for HTML "meta redirects" on pages of sites that have been migrated
+    # to Federalist. For context, see https://github.com/18F/federalist-proxy/issues/19.
+    #
+    # More extensions can be added inside the parentheses, separated
+    # by | characters, e.g. `\.(cfm|php)$`.
+    location ~* \.(cfm)$ {
+      add_header Content-Type "text/html";
+      add_header Strict-Transport-Security $sts always;
+      add_header X-Frame-Options "SAMEORIGIN";
+      add_header X-Server "Federalist";
+
+      proxy_pass $bucket_url;
+      proxy_hide_header Content-Type;
+      proxy_intercept_errors on;
+      error_page 404 403 =404 @notfound;
+    }
+
+    # Match paths with extensions and possibly query parameters
+    location ~ ^/[^/]+/(?<owner>([^/]+))/(?<repo>([^/]+))/[^?]*\.[^./]+(\?.*)?$ {
+      proxy_pass $bucket_url;
+      proxy_intercept_errors on;
+      error_page 404 403 =404 @notfound;
+    }
+
+    # What is left are paths without extensions
+    location / {
+      rewrite ^(.*)$ https://$host$1/ permanent;
+    }
+
     location @notfound {
       # custom 404 pages are *bucket* specific NOT *branch* specific
       proxy_pass $bucket_url/site/$owner/$repo/404.html;
-    }
-
-    location / {
-      location ~ ^/[^/]+/(?<owner>([^/]+))/(?<repo>([^/]+))/ {
-
-        # Specify the Content-Type header as "text/html" for requests that look
-        # like they are for files with specific extensions. This is primarily to
-        # allow for HTML "meta redirects" on pages of sites that have been migrated
-        # to Federalist. For context, see https://github.com/18F/federalist-proxy/issues/19.
-        #
-        # More extensions can be added inside the parentheses, separated
-        # by | characters, e.g. `\.(cfm|php)$`.
-        location ~* \.(cfm)$ {
-          add_header Content-Type "text/html";
-          add_header Strict-Transport-Security $sts always;
-          add_header X-Frame-Options "SAMEORIGIN";
-          add_header X-Server "Federalist";
-
-          proxy_pass $bucket_url;
-          proxy_hide_header Content-Type;
-          proxy_intercept_errors on;
-          error_page 404 403 =404 @notfound;
-        }
-
-        # Match paths with extensions and possibly query parameters
-        location ~ [^?]*\.[^./]+(\?.*)?$ {
-          proxy_pass $bucket_url;
-          proxy_intercept_errors on;
-          error_page 404 403 =404 @notfound;
-        }
-
-        # Match paths ending in '/'
-        location ~ /$ {
-          rewrite ^(.*)$ $1index.html last;
-        }
-
-        # What is left are paths without extensions
-        rewrite ^(.*)$ $1/ permanent;
-      }
     }
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -188,7 +188,7 @@ function pathSpecs(host, prefixPathFn) {
           return makeRequest(path, host, [
             [301],
             ['Content-Type', 'text/html'],
-            ['Location', `http://${host}${path}/`],
+            ['Location', `https://${host}${path}/`],
           ]);
         });
 
@@ -199,7 +199,7 @@ function pathSpecs(host, prefixPathFn) {
             return makeRequest(`${path}${query}`, host, [
               [301],
               ['Content-Type', 'text/html'],
-              ['Location', `http://${host}${path}/${query}`],
+              ['Location', `https://${host}${path}/${query}`],
             ]);
           });
         });
@@ -211,7 +211,7 @@ function pathSpecs(host, prefixPathFn) {
           return makeRequest(path, host, [
             [301],
             ['Content-Type', 'text/html'],
-            ['Location', `http://${host}${path}/`],
+            ['Location', `https://${host}${path}/`],
           ]);
         });
       });
@@ -222,7 +222,7 @@ function pathSpecs(host, prefixPathFn) {
           return makeRequest(path, host, [
             [301],
             ['Content-Type', 'text/html'],
-            ['Location', `http://${host}${path}/`],
+            ['Location', `https://${host}${path}/`],
           ]);
         });
       });
@@ -233,7 +233,7 @@ function pathSpecs(host, prefixPathFn) {
           return makeRequest(path, host, [
             [301],
             ['Content-Type', 'text/html'],
-            ['Location', `http://${host}${path}/`],
+            ['Location', `https://${host}${path}/`],
           ]);
         });
       })
@@ -246,7 +246,7 @@ function pathSpecs(host, prefixPathFn) {
           return makeRequest(path, host, [
             [301],
             ['Content-Type', 'text/html'],
-            ['Location', `http://${host}${path}/`],
+            ['Location', `https://${host}${path}/`],
           ]);
         });
       });


### PR DESCRIPTION
## Changes proposed in this pull request:
- Addresses #121 
- Explicitly redirects using https

This is necessary bc nginx always prepends `$scheme://$host` to any relative path so we have to set it explicitly.

## security considerations
None
