### PR TITLE
set redirect path based on user agent header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -58,6 +58,11 @@ http {
     ~({{env "FEDERALIST_PROXY_SERVER_NAME"}}) {{env "FEDERALIST_S3_BUCKET_URL"}};
   }
 
+  map $http_user_agent $prefix_path {
+    default $full_path;
+    "Amazon Cloudfront" $rest;
+  }
+  
   server {
     listen {{port}};
     server_name ~^(?<name>.+)\.{{env "DOMAIN"}}$;
@@ -75,22 +80,24 @@ http {
       return 200 "Ok";
     }
 
-    # Match paths ending in '/'
-    location ~ /$ {
-      rewrite ^(.*)$ $1index.html last;
-    }
+    location ~ ^/(?<context>([^/]+))/(?<owner>([^/]+))/(?<repo>([^/]+))(?<rest>(.*))$ {
+      # Match paths ending in '/'
+      location ~ /$ {
+        rewrite ^(.*)$ $1index.html last;
+      }
 
-    # Match paths with extensions and possibly query parameters
-    location ~ ^/[^/]+/(?<owner>([^/]+))/(?<repo>([^/]+))/[^?]*\.[^./]+(\?.*)?$ {
-      proxy_pass $bucket_url;
-      proxy_intercept_errors on;
-      error_page 404 403 =404 @notfound;
-    }
-
-    # What is left are paths without extensions
-    location / {
-      absolute_redirect off;
-      rewrite ^(.*)$ $1/ permanent;
+      # Match paths with extensions and possibly query parameters
+      location ~ ^/[^/]+/[^/]+/[^/]+/[^?]*\.[^./]+(\?.*)?$ {
+        proxy_pass $bucket_url;
+        proxy_intercept_errors on;
+        error_page 404 403 =404 @notfound;
+      }
+      
+      # What is left are paths without extensions
+      location ~ ^/ {
+        absolute_redirect off;
+        rewrite ^(?<full_path>(.*))$ $prefix_path/ permanent;
+      }
     }
 
     location @notfound {


### PR DESCRIPTION
## Changes proposed in this pull request:
- redirects based on user agent header (if Amazon Cloudfront)
- #121 

## security considerations
None -  but it is a string comparison and redirects are relative only
