### PR TITLE
Return 404s for backslashes at site root or after

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -98,7 +98,7 @@ http {
       
       # Match paths with backslashes at site root or after
       location ~ ^/[^/]+/[^/]+/[^/]+/.*[\\\]+ {
-        return 404 "Not Found";
+        rewrite ^(.*)$ @notfound;
       }
       
       # What is left are paths without extensions

--- a/nginx.conf
+++ b/nginx.conf
@@ -83,7 +83,7 @@ http {
       return 200 "Ok";
     }
 
-    location ~ ^/(?<context>([^/]+))/(?<owner>([^/]+))/(?<repo>([^/]+))(?<rest>(.*))$ {
+    location ~ ^/(?<context>(site|preview|demo))/(?<owner>([^/]+))/(?<repo>([^/]+))(?<rest>(.*))$ {
       # Match paths ending in '/'
       location ~ /$ {
         rewrite ^(.*)$ $1index.html last;
@@ -94,6 +94,11 @@ http {
         proxy_pass $bucket_url;
         proxy_intercept_errors on;
         error_page 404 403 =404 @notfound;
+      }
+      
+      # Match paths with backslashes at site root or after
+      location ~ ^/[^/]+/[^/]+/[^/]+/.*[\\\]+ {
+        return 404 "Not Found";
       }
       
       # What is left are paths without extensions

--- a/test/main.js
+++ b/test/main.js
@@ -238,20 +238,49 @@ function pathSpecs(host, prefixPathFn) {
         });
       })
 
-      describe('when from cloudfront', () => {
+      if(prefixPathFn.toString() === 'preview path') {
+        it('redirects to /<some-path>/ with the prefix', () => {
+          const path = prefixPathFn('/unicorn');
+          const location = prefixPathFn('/unicorn/');
+
+          return makeRequest(path, host, [
+            [301],
+            ['Content-Type', 'text/html'],
+            ['Location', location],
+          ]);
+        });
+
+        describe('for potential open redirects', () => {
+          it('returns a 404', () => {
+            const path = prefixPathFn(encodeURI('/\\\\example.com/%2e%2e%2f')); // /%5C%5Cexample.com/%252e%252e%252f
+
+            return makeRequest(path, host, [
+              [404],
+            ]);
+          });
+        });
+      } else {
         it('redirects to /<some-path>/ without the prefix', () => {
           const path = prefixPathFn('/unicorn');
-          const location = prefixPathFn.toString() === 'preview path'
-            ? '/branch/name/unicorn/'
-            : '/unicorn/';
+          const location = '/unicorn/';
 
           return makeCloudfrontRequest(path, host, [
             [301],
             ['Content-Type', 'text/html'],
             ['Location', location],
           ]);
-        })
-      });
+        });
+
+        describe('for potential open redirects', () => {
+          it('returns a 404', () => {
+            const path = prefixPathFn(encodeURI('/\\\\example.com/%2e%2e%2f')); // /%5C%5Cexample.com/%252e%252e%252f
+
+            return makeCloudfrontRequest(path, host, [
+              [404],
+            ]);
+          });
+        });
+      }
     });
 
     describe('/<some-path-with-period>', () => {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Returns 404s if backslashes exist in certain parts of the path

## security considerations
yes
