### PR TITLE
Serve 404s for Dockerfile and docker-compose.yml

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -89,6 +89,11 @@ http {
         rewrite ^(.*)$ $1index.html last;
       }
 
+      # Match forbidden files
+      location ~ (Dockerfile|docker-compose\.yml) {
+        rewrite ^(.*)$ @notfound;
+      }
+
       # Match paths with extensions and possibly query parameters
       location ~ ^/[^/]+/[^/]+/[^/]+/[^?]*\.[^./]+(\?.*)?$ {
         proxy_pass $bucket_url;

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -51,6 +51,14 @@ function getFixtures(bucketType) {
       content: '<h1>default - 4044444444</h1>',
       extras: { ContentType: 'text/html' },
     },
+    ...prefixPaths('Dockerfile', {
+      content: 'Docker!',
+      extras: { ContentType: 'text/plain' },
+    }),
+    ...prefixPaths('docker-compose.yml', {
+      content: 'Docker Docker Docker!',
+      extras: { ContentType: 'text/plain' },
+    }),
   };
 };
 

--- a/test/main.js
+++ b/test/main.js
@@ -296,6 +296,26 @@ function pathSpecs(host, prefixPathFn) {
       });
     });
 
+    describe('/<paths-to-docker-files>', () => {
+      describe('when a Dockerfile is requested', () => {
+        it('serves the default 404.html', () => {
+          const path = prefixPathFn('/Dockerfile');
+          return makeRequest(path, host, [
+            [404],
+          ]);
+        });
+      });
+
+      describe('when a docker-compose.yml file is requested', () => {
+        it('serves the default 404.html', () => {
+          const path = prefixPathFn('/docker-compose.yml');
+          return makeRequest(path, host, [
+            [404],
+          ]);
+        });
+      });
+    });
+
     describe('/<some-path>/', () => {
       describe('when /<some-path>/index.html exists', () => {
         it('serves /<some-path>/index.html', () => {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Requests for `Dockerfile` or `docker-compose.yml` get the standard 404 response.

Work in service of #104 

## security considerations
Better encapsulation of container details
