### PR TITLE
Explicitly set CircleCI image to use Ubuntu 20.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,8 @@ log-out-of-cloudgov: &log-out-of-cloudgov
 ##################################
 jobs:
   build-and-test:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Explicitly set CircleCI image to use Ubuntu 20.04

to address the need documented in #142 (whoops; I typoed my branch name 😬).

This change is necessary because CircleCI has deprecated the default Ubuntu 14.04 image and it will stop working after May 2021. Because we were setting
```yml
  machine: true
```
we were getting that default. I have changed this to
```yml
  machine:
    image: image: ubuntu-2004:202201-02
```

in accordance with CircleCI's migration documentation, which is at
https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/

## security considerations
None
