### PR TITLE
Use X-Robots-Tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
   nginx:
     image: openresty/openresty:1.19.9.1-4-buster
     volumes:
-      - ./public/robots.txt:/usr/share/nginx/html/public/robots.txt:ro
       - ./tmp/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
       - ./mime.types:/etc/nginx/mime.types:ro
     restart: always

--- a/nginx.conf
+++ b/nginx.conf
@@ -67,7 +67,7 @@ http {
   }
 
   map $http_user_agent $robot_header {
-    default "noindex";
+    default "none";
     "Amazon Cloudfront" "all";
   }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -65,7 +65,12 @@ http {
     default $full_path;
     "Amazon Cloudfront" $rest;
   }
-  
+
+  map $http_user_agent $robot_header {
+    default "noindex";
+    "Amazon Cloudfront" "";
+  }
+
   server {
     listen {{port}};
     server_name ~^(?<name>.+)\.{{env "DOMAIN"}}$;
@@ -73,10 +78,7 @@ http {
     add_header Strict-Transport-Security $sts always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Server "Federalist" always;
-
-    location =/robots.txt {
-      alias {{env "HOME"}}/public/robots.txt;
-    }
+    add_header X-Robots-Tag $robot_header always;
 
     location =/health {
       access_log off;
@@ -95,12 +97,12 @@ http {
         proxy_intercept_errors on;
         error_page 404 403 =404 @notfound;
       }
-      
+
       # Match paths with backslashes at site root or after
       location ~ ^/[^/]+/[^/]+/[^/]+/.*[\\\]+ {
         rewrite ^(.*)$ @notfound;
       }
-      
+
       # What is left are paths without extensions
       location ~ ^/ {
         absolute_redirect off;

--- a/nginx.conf
+++ b/nginx.conf
@@ -68,7 +68,7 @@ http {
 
   map $http_user_agent $robot_header {
     default "noindex";
-    "Amazon Cloudfront" "";
+    "Amazon Cloudfront" "all";
   }
 
   server {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/test/main.js
+++ b/test/main.js
@@ -14,7 +14,7 @@ const {
 supertest.Test.prototype.expectStandardHeaders = function() {
   this.expect('X-Frame-Options', 'SAMEORIGIN');
   this.expect('X-Server', 'Federalist');
-  this.expect('X-Robots-Tag', 'noindex');
+  this.expect('X-Robots-Tag', 'none');
   this.expect('Strict-Transport-Security', /max-age=31536000; preload/);
 
   return this;

--- a/test/main.js
+++ b/test/main.js
@@ -14,9 +14,18 @@ const {
 supertest.Test.prototype.expectStandardHeaders = function() {
   this.expect('X-Frame-Options', 'SAMEORIGIN');
   this.expect('X-Server', 'Federalist');
+  this.expect('X-Robots-Tag', 'noindex');
   this.expect('Strict-Transport-Security', /max-age=31536000; preload/);
   return this;
 }
+
+supertest.Test.prototype.expectCloudfrontHeaders = function() {
+  this.expect("X-Frame-Options", "SAMEORIGIN");
+  this.expect("X-Server", "Federalist");
+  this.expect("Strict-Transport-Security", /max-age=31536000; preload/);
+
+  return this;
+};
 
 const request = supertest(PROXY_URL);
 
@@ -34,8 +43,8 @@ function makeCloudfrontRequest(path, host, expectations = []) {
     .get(path)
     .set('Host', host)
     .set('User-Agent', 'Amazon Cloudfront')
-    .expectStandardHeaders();
-  
+    .expectCloudfrontHeaders();
+
   return expectations.reduce((r, expectation) => r.expect(...expectation), initial);
 }
 
@@ -101,17 +110,6 @@ describe('parse-conf', () => {
       set $bucket_url http://${value};
       bar;
     `);
-  });
-});
-
-describe('robots.txt', () => {
-  it('is available', () => {
-    return request
-      .get('/robots.txt')
-      .expectStandardHeaders()
-      .expect(200)
-      .expect('Content-Type', /text\/plain/)
-      .expect(/Disallow/);
   });
 });
 

--- a/test/main.js
+++ b/test/main.js
@@ -16,13 +16,15 @@ supertest.Test.prototype.expectStandardHeaders = function() {
   this.expect('X-Server', 'Federalist');
   this.expect('X-Robots-Tag', 'noindex');
   this.expect('Strict-Transport-Security', /max-age=31536000; preload/);
+
   return this;
 }
 
 supertest.Test.prototype.expectCloudfrontHeaders = function() {
-  this.expect("X-Frame-Options", "SAMEORIGIN");
-  this.expect("X-Server", "Federalist");
-  this.expect("Strict-Transport-Security", /max-age=31536000; preload/);
+  this.expect('X-Frame-Options', 'SAMEORIGIN');
+  this.expect('X-Server', 'Federalist');
+  this.expect('X-Robots-Tag', 'all');
+  this.expect('Strict-Transport-Security', /max-age=31536000; preload/);
 
   return this;
 };
@@ -110,6 +112,15 @@ describe('parse-conf', () => {
       set $bucket_url http://${value};
       bar;
     `);
+  });
+});
+
+describe('robots.txt', () => {
+  it('is not present', () => {
+    return request
+      .get('/robots.txt')
+      .expectStandardHeaders()
+      .expect(404)
   });
 });
 


### PR DESCRIPTION
Relates to https://github.com/18F/federalist-proxy/issues/111

## Changes proposed in this pull request:
- Remove static robots.txt file from being served
- Add `X-Robots-Tag` to non-Cloudfront requests based on User Agent

## security considerations
I believe that if someone were to modify their user agent they could potentially have a non-Cloudfront request served without the `X-Robots-Tag`, potentially making it indexable, however without tracking all of AWS's Cloudfront IPs the user agent appears to be the only other way to identify Cloudfront requests.
