### PR TITLE
Explicitly set the _rest_ of the CircleCI machines to use Ubuntu 20.04.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,8 @@ jobs:
           command: docker-compose run app npm test
 
   build-and-test-integration:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
       - run:
@@ -84,7 +85,8 @@ jobs:
           command: docker-compose run app npm run test:integration:website-config
 
   deploy:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     environment:
       CF_MANIFEST: ./.cloudgov/manifest.yml
     steps:
@@ -97,7 +99,8 @@ jobs:
       - *log-out-of-cloudgov
 
   recycle:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     steps:
       - *maybe-configure-production
       - *maybe-configure-staging


### PR DESCRIPTION
## Changes proposed in this pull request:
- Explicitly set CircleCI image to use Ubuntu 20.04 — just like I did in #143, but *this* time I also did it in the three CircleCI machines I missed.

to address the need documented in #142.

This change is necessary because CircleCI has deprecated the default Ubuntu 14.04 image and it will stop working after May 2021. Because we were setting
```yml
  machine: true
```
we were getting that default. I have changed this to
```yml
  machine:
    image: image: ubuntu-2004:202201-02
```

in accordance with CircleCI's migration documentation, which is at
https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/

## security considerations
None
