### PR TITLE
Add x-amz-expected-bucket-owner to the list of headers not passed to S3

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -48,6 +48,7 @@ http {
   proxy_set_header If-Unmodified-Since "";
   proxy_set_header Range "";
   proxy_set_header If-Range "";
+  proxy_set_header x-amz-expected-bucket-owner "";
 
   map_hash_max_size 64;
   map_hash_bucket_size 256;


### PR DESCRIPTION
## Changes proposed in this pull request:
- Resolve cache poisoning

## security considerations
Omits x-amz-expected-bucket-owner from being passed to S3
