### PR TITLE
Fixed the set-pipeline job to federalist-proxy pipeline

### DIFF
--- a/ci/federalist-pipeline.yml
+++ b/ci/federalist-pipeline.yml
@@ -107,11 +107,8 @@ jobs:
     - get: src
       resource: src-production
       trigger: true
-    - set_pipeline: proxy
+    - set_pipeline: federalist-proxy
       file: src/ci/federalist-pipeline.yml
-      instance_vars:
-        deploy-env: production
-        git-branch: main
 
   - name: test-pr-main
     plan:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixed the set-pipeline task to set the pipeline for federalist-proxy and not the pages proxy pipeline.

## security considerations
None
